### PR TITLE
Unread indicators

### DIFF
--- a/client/components/conversation-list.js
+++ b/client/components/conversation-list.js
@@ -40,14 +40,14 @@ module.exports = ({ phones, activePhone, isAdding, onClickAdd, onSubmitAdd }) =>
 
   function listItem (phone) {
     const classes = ['pure-menu-item']
-    if (activePhone && activePhone === phone) {
+    if (activePhone && activePhone === phone.label) {
       classes.push('pure-menu-selected')
     }
 
     return html`
       <li class=${classes.join(' ')}>
-        <a href="/${phone}" class="pure-menu-link">
-          ${formatPhone(phone)}
+        <a href="/${phone.label}" class="pure-menu-link">
+          ${formatPhone(phone.label)} ${phone.unread > 0 ? html`<small>(${phone.unread})</small>` : ''}
         </a>
       </li>`
   }

--- a/client/components/conversation-list.js
+++ b/client/components/conversation-list.js
@@ -19,11 +19,20 @@ const prefix = css`
   .pure-menu-heading {
     color: #B8DBD9;
   }
-  .new-conversation {
+  .align-right {
     position: absolute;
     right: 15px;
     top: 8px;
+  }
+  .new-conversation {
     color: #B8DBD9;
+  }
+  .unread-count {
+    font-size: 80%;
+    padding: 3px 9px;
+    background-color: #f4f4f9;
+    color: #000;
+    border-radius: 10px;
   }
 `
 
@@ -31,7 +40,7 @@ module.exports = ({ phones, activePhone, isAdding, onClickAdd, onSubmitAdd }) =>
   return html`
   <div class="pure-menu ${prefix}">
     <span class="pure-menu-heading">Conversations</span>
-    <a href="#" onclick=${clickAdd} class="new-conversation"><i class="fa fa-plus-square"></i></a>
+    <a href="#" onclick=${clickAdd} class="new-conversation align-right"><i class="fa fa-plus-square"></i></a>
     <ul id="conversations" class="pure-menu-list">
       ${isAdding ? addForm() : ''}
       ${phones.map(listItem)}
@@ -47,7 +56,8 @@ module.exports = ({ phones, activePhone, isAdding, onClickAdd, onSubmitAdd }) =>
     return html`
       <li class=${classes.join(' ')}>
         <a href="/${phone.label}" class="pure-menu-link">
-          ${formatPhone(phone.label)} ${phone.unread > 0 ? html`<small>(${phone.unread})</small>` : ''}
+          ${formatPhone(phone.label)}
+          ${phone.unread > 0 ? html`<span class="unread-count align-right">${phone.unread}</span>` : ''}
         </a>
       </li>`
   }

--- a/client/models/conversations.js
+++ b/client/models/conversations.js
@@ -14,6 +14,7 @@ module.exports = {
   state: {
     user: {},
     messages: {},
+    lastRead: {'+11628737261': '2015-02-10'}, // { '+12151231234': '2016-08-22T00:01:02Z' }
     isAddingConversation: false
   },
   reducers: {
@@ -22,17 +23,18 @@ module.exports = {
       const newMessages = extend(state.messages, keyedMessages)
       return { messages: newMessages }
     },
-    // receive: (messages, state) => {
-    //   const newConversations = createIndexes(messages)
-    //   const oldConversations = cloneDeep(state.conversations) // because merge mutates
-    //   const mergedConversations = merge(oldConversations, newConversations)
-    //   return { conversations: mergedConversations }
-    // },
     setAddingConversation: (isAddingConversation, state) => {
       return { isAddingConversation }
     },
     setUser: (userCtx, state) => {
       return { user: userCtx }
+    },
+    setLastRead: (data, state) => {
+      const { phone, date } = data
+      if (!state.lastRead[phone] || date > state.lastRead[phone]) {
+        const newLastRead = extend(state.lastRead, { [phone]: date })
+        return { lastRead: newLastRead }
+      }
     }
   },
   effects: {
@@ -113,12 +115,3 @@ module.exports = {
     }
   }
 }
-
-// function createIndexes (messages) {
-//   const convosByPhone = groupBy(messages, (msg) => msg.direction === 'inbound' ? msg.from : msg.to)
-//   const convosByPhoneByID = {}
-//   for (let phone in convosByPhone) {
-//     convosByPhoneByID[phone] = keyBy(convosByPhone[phone], '_id')
-//   }
-//   return convosByPhoneByID
-// }


### PR DESCRIPTION
Closes #4. This is not an ideal approach but an MVP one.

* [x] Store timestamp of last read message for each conversation
* [x] Indicate unread count on UI for each conversation
* [x] Update last read message date when conversation comes into view
* [x] Store "last read" timestamps in persistent storage (pouchdb, localStorage, etc.)
* [x] Improve unread count UI (badge floated to the right)