### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/client/models/user.js
+++ b/client/models/user.js
@@ -1,6 +1,6 @@
 const series = require('run-series')
 const http = require('choo/http')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 module.exports = (db, initialState) => ({
   namespace: 'user',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lodash": "^4.14.1",
     "meow": "^3.7.0",
     "nano": "^6.2.0",
-    "node-uuid": "^1.4.7",
     "postmark": "^1.2.1",
     "pouchdb": "^5.4.5",
     "pouchdb-authentication": "^0.5.4",
@@ -49,6 +48,7 @@
     "shortid": "^2.2.6",
     "timeago.js": "^1.0.5",
     "twilio": "^2.9.1",
+    "uuid": "^3.0.0",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/server/reset-password.js
+++ b/server/reset-password.js
@@ -1,4 +1,4 @@
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const extend = require('xtend')
 const path = require('path')
 const stripIndent = require('common-tags').stripIndent


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.